### PR TITLE
refactor: export TS types as constants instead of string

### DIFF
--- a/generate.ts
+++ b/generate.ts
@@ -30,7 +30,7 @@ function generateContent(): string {
     .map(
       (key) => `\t${key}: {
     ${generateEntries(json[key])}
-  }`
+  } as const`
     )
     .join("\n,");
 }


### PR DESCRIPTION
Currently, the **exported types `index.d.ts`** from this package are represented as a string 

```ts
 keys: {
        acct_sk: string;
        acct_vk: string;
}
``` 

It will make sense to represent it as its literal value

```ts
keys: {
        readonly acct_sk: "acct_sk";
        readonly acct_vk: "acct_vk";
}
```
